### PR TITLE
Introduce (optional) type aliases

### DIFF
--- a/fastJSON/JSON.cs
+++ b/fastJSON/JSON.cs
@@ -26,7 +26,6 @@ namespace fastJSON
 	{
 		static JSONParameters _Parameters = new JSONParameters();
 		static SerializationManager _Manager = SerializationManager.Instance;
-		static SafeDictionary<string, string> _TypeAliases = null, _ReverseTypeAliases = null;
 		/// <summary>
 		/// Gets or sets global parameters for the serializer.
 		/// </summary>
@@ -104,44 +103,7 @@ namespace fastJSON
 			}
 
 			ReflectionCache c = manager.GetReflectionCache (obj.GetType ());
-			return new JsonSerializer(param, manager, _TypeAliases).ConvertToJSON(obj, c);
-		}
-
-		public static void SetTypeAlias(Dictionary<Type, string> list)
-		{
-			if (null == list)
-			{
-				_TypeAliases = _ReverseTypeAliases = null;
-				return;
-			}
-			_TypeAliases = new SafeDictionary<string, string>();
-			// Deserializer needs a reverse lookup dictionary
-			_ReverseTypeAliases = new SafeDictionary<string, string>();
-			foreach (KeyValuePair<Type, string> item in list)
-			{
-				_TypeAliases.Add(item.Key.AssemblyQualifiedName, item.Value);
-				_ReverseTypeAliases.Add(item.Value, item.Key.AssemblyQualifiedName);
-			}
-		}
-
-		public static void SetTypeAlias(List<Type> list)
-		{
-			if (null == list)
-			{
-				_TypeAliases = _ReverseTypeAliases = null;
-				return;
-			}
-			_TypeAliases= new SafeDictionary<string, string>();
-			_ReverseTypeAliases = new SafeDictionary<string, string>();
-			foreach (Type item in list)
-			{
-				JsonTypeAttribute att= AttributeHelper.GetAttribute<JsonTypeAttribute>(item, false);
-				if (null == att)
-					continue;
-
-				_TypeAliases.Add(item.AssemblyQualifiedName, att.Name);
-				_ReverseTypeAliases.Add(att.Name, item.AssemblyQualifiedName);
-			}
+			return new JsonSerializer(param, manager).ConvertToJSON(obj, c);
 		}
 
 		/// <summary>
@@ -172,7 +134,7 @@ namespace fastJSON
 		/// <returns>The deserialized object of type <typeparamref name="T"/>.</returns>
 		public static T ToObject<T>(string json)
 		{
-			return new JsonDeserializer(Parameters, Manager, _ReverseTypeAliases).ToObject<T>(json);
+			return new JsonDeserializer(Parameters, Manager).ToObject<T>(json);
 		}
 		/// <summary>
 		/// Create a typed generic object from the JSON with parameter override on this call.

--- a/fastJSON/JsonDeserializer.cs
+++ b/fastJSON/JsonDeserializer.cs
@@ -18,7 +18,6 @@ namespace fastJSON
 		readonly Dictionary<int, object> _cirrev = new Dictionary<int, object> ();
 		bool _usingglobals = false;
 		Dictionary<string,object> globaltypes;
-		readonly SafeDictionary<string, string> _typeAliases = null;
 		readonly bool _useTypeAlias;
 
 		static RevertJsonValue[] RegisterMethods () {
@@ -50,11 +49,10 @@ namespace fastJSON
 			return r;
 		}
 
-		public JsonDeserializer (JSONParameters param, SerializationManager manager, SafeDictionary<string, string> typeAliases = null) {
+		public JsonDeserializer (JSONParameters param, SerializationManager manager) {
 			_params = param;
 			_manager = manager;
-			_typeAliases = typeAliases;
-			_useTypeAlias = (null != _typeAliases);
+			_useTypeAlias = (0 < _manager.TypeAliasCount());
 		}
 
 		public T ToObject<T>(string json) {
@@ -249,7 +247,7 @@ namespace fastJSON
 				}
 			}
 
-			var tn = _useTypeAlias? LookupAlias(data.Type) : data.Type;
+			var tn = _useTypeAlias? _manager.ReverseLookupAlias(data.Type) : data.Type;
 			bool found = (tn != null && tn.Length > 0);
 #if !SILVERLIGHT
 			if (found == false && type != null && typeof (object).Equals (type.Type)) {
@@ -385,18 +383,6 @@ namespace fastJSON
 				si.OnDeserialized (o);
 			}
 			return o;
-		}
-
-
-		private string LookupAlias(string assemblyName)
-		{
-			if (null == _typeAliases || null == assemblyName)
-				return assemblyName;
-			string alias = null;
-			_typeAliases.TryGetValue(assemblyName, out alias);
-			if (null == alias)
-				return assemblyName;
-			return alias;
 		}
 
 

--- a/fastJSON/SerializationAttributes.cs
+++ b/fastJSON/SerializationAttributes.cs
@@ -74,6 +74,32 @@ namespace fastJSON
 	}
 
 	/// <summary>
+	/// Indicates the name of the serialized data type.
+	/// If unset, the assembly qualified name is used.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+	public sealed class JsonTypeAttribute :Attribute
+	{
+		/// <summary>
+		/// Gets the name of the serialized class.
+		/// The case of the serialized name defined in this attribute will not be changed by <see cref="JSONParameters.NamingConvention"/> setting in <see cref="JSONParameters"/>.
+		/// </summary>
+		public string Name
+		{
+			get; private set;
+		}
+
+		/// <summary>
+		/// Specifies the name of the serialized field or property.
+		/// </summary>
+		/// <param name="name">The name of the serialized field or property.</param>
+		public JsonTypeAttribute(string name)
+		{
+			Name = name;
+		}
+	}
+
+	/// <summary>
 	/// Specifies a value of the annotated member which is hidden from being serialized.
 	/// </summary>
 	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]


### PR DESCRIPTION
Provides a simple way to allow type aliases for serialized types. Instead of
relying on the AssemblyQualifiedName, an arbitrary user-defined string can
be registered as a substitute.
This allows interfacing with software not under control of the same developer
without having to mimick the namespace structure on the far end of the
protocol. Also, this allows a sane way of serializing types in the presence of
code obfuscation (a necessary evil in the world of introspectable languages),
especially since obfuscated names change from one obfuscator run to the next.
